### PR TITLE
fix more UI issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hiplot-mm"
-version = "0.0.4rc12"
+version = "0.0.4rc13"
 description = "High dimensional Interactive Plotting tool"
 readme = "README.md"
 license = "MIT"

--- a/src/parallel/parallel.tsx
+++ b/src/parallel/parallel.tsx
@@ -977,14 +977,8 @@ export class ParallelPlot extends React.Component<ParallelPlotData, ParallelPlot
     // update axes
     div.selectAll("." + pstyle.axis).each((d: string, i, nodes) => {
       const node = nodes[i];
-      // hide lines for better performance
-      d3.select(node).selectAll("line").style("display", "none");
-
       // transition axis numbers
       d3.select(node).transition().duration(720).call(this.get_axis(d));
-
-      // bring lines back
-      d3.select(node).selectAll("line").transition().delay(800).style("display", null);
 
       d3.select(node).selectAll("text").style("font-weight", null).style("font-size", null);
     });

--- a/src/parallel/parallel.tsx
+++ b/src/parallel/parallel.tsx
@@ -980,7 +980,7 @@ export class ParallelPlot extends React.Component<ParallelPlotData, ParallelPlot
       // transition axis numbers
       d3.select(node).transition().duration(720).call(this.get_axis(d));
 
-      d3.select(node).selectAll("text").style("font-weight", null).style("font-size", null);
+      d3.select(node).selectAll(".tick text").style("font-weight", null).style("font-size", null);
     });
     this.setState(function (prevState) {
       return { brush_count: prevState.brush_count + 1 };

--- a/src/parallel/parallel.tsx
+++ b/src/parallel/parallel.tsx
@@ -974,10 +974,6 @@ export class ParallelPlot extends React.Component<ParallelPlotData, ParallelPlot
         });
     }
 
-    // show ticks
-    div.selectAll("." + pstyle.axis + " g").style("display", null);
-    div.selectAll(".background").style("visibility", null);
-
     // update axes
     div.selectAll("." + pstyle.axis).each((d: string, i, nodes) => {
       const node = nodes[i];
@@ -990,11 +986,7 @@ export class ParallelPlot extends React.Component<ParallelPlotData, ParallelPlot
       // bring lines back
       d3.select(node).selectAll("line").transition().delay(800).style("display", null);
 
-      d3.select(node)
-        .selectAll("text")
-        .style("font-weight", null)
-        .style("font-size", null)
-        .style("display", null);
+      d3.select(node).selectAll("text").style("font-weight", null).style("font-size", null);
     });
     this.setState(function (prevState) {
       return { brush_count: prevState.brush_count + 1 };

--- a/src/plotxy.tsx
+++ b/src/plotxy.tsx
@@ -215,6 +215,28 @@ export class PlotXY extends React.Component<PlotXYProps, PlotXYState> {
       }
       return d3.format(".3~e");
     }
+    function getTickValues(param: string, scale: any, approxTickCount: number): any[] | null {
+      const paramDef = me.props.params_def[param];
+      if (
+        !paramDef ||
+        paramDef.type !== ParamType.NUMERICLOG ||
+        typeof scale.ticks !== "function"
+      ) {
+        return null;
+      }
+      const ticks = scale.ticks(approxTickCount);
+      if (!Array.isArray(ticks)) {
+        return null;
+      }
+      const majorTicks = ticks.filter((tick: number) => {
+        if (!Number.isFinite(tick) || tick <= 0) {
+          return false;
+        }
+        const lg = Math.log10(tick);
+        return Math.abs(lg - Math.round(lg)) < 1e-10;
+      });
+      return majorTicks.length > 1 ? majorTicks : null;
+    }
     function redraw_axis() {
       me.svg.selectAll(".axis_render").remove();
       me.svg.selectAll(".brush").remove();
@@ -242,6 +264,10 @@ export class PlotXY extends React.Component<PlotXYProps, PlotXYState> {
       ]);
       const xTickFormatter = getTickFormatter(me.state.axis_x, x_scale);
       const yTickFormatter = getTickFormatter(me.state.axis_y, y_scale);
+      const yTickCount = 1 + me.state.height / 40;
+      const xTickCount = 1 + me.state.width / 80;
+      const xTickValues = getTickValues(me.state.axis_x, x_scale, xTickCount);
+      const yTickValues = getTickValues(me.state.axis_y, y_scale, yTickCount);
       zoom_brush = d3
         .brush()
         .extent([
@@ -256,7 +282,8 @@ export class PlotXY extends React.Component<PlotXYProps, PlotXYState> {
           .call(
             d3
               .axisLeft(y_scale)
-              .ticks(1 + me.state.height / 40)
+              .ticks(yTickCount)
+              .tickValues(yTickValues as any)
               .tickFormat(yTickFormatter as any)
               .tickSizeInner(margin.left + margin.right - me.state.width),
           )
@@ -289,7 +316,8 @@ export class PlotXY extends React.Component<PlotXYProps, PlotXYState> {
           .call(
             d3
               .axisBottom(x_scale)
-              .ticks(1 + me.state.width / 80)
+              .ticks(xTickCount)
+              .tickValues(xTickValues as any)
               .tickFormat(xTickFormatter as any)
               .tickSizeInner(margin.bottom + margin.top - me.state.height),
           )

--- a/src/plotxy.tsx
+++ b/src/plotxy.tsx
@@ -192,14 +192,16 @@ export class PlotXY extends React.Component<PlotXYProps, PlotXYState> {
       if (!paramDef) {
         return null;
       }
+      if (paramDef.type === ParamType.TIMESTAMP) {
+        return null;
+      }
       if (paramDef.ticks_format) {
         return d3.format(paramDef.ticks_format);
       }
       const isNumericLike =
         paramDef.type === ParamType.NUMERIC ||
         paramDef.type === ParamType.NUMERICLOG ||
-        paramDef.type === ParamType.NUMERICPERCENTILE ||
-        paramDef.type === ParamType.TIMESTAMP;
+        paramDef.type === ParamType.NUMERICPERCENTILE;
       if (!isNumericLike || typeof scale.domain !== "function") {
         return null;
       }

--- a/src/rowsdisplaytable.tsx
+++ b/src/rowsdisplaytable.tsx
@@ -69,6 +69,24 @@ export class RowsDisplayTable extends React.Component<TablePluginProps, RowsDisp
 
   setSelected_debounced = _.debounce(this.setSelected, 150);
 
+  private getUidFromRowData(rowData: Array<any>): string {
+    const uidIdx = this.ordered_cols.indexOf("uid");
+    if (uidIdx >= 0) {
+      const direct = rowData[uidIdx];
+      if (this.props.dp_lookup[direct] !== undefined) {
+        return direct;
+      }
+      if (this.dt && this.dt.colReorder) {
+        const reorderedUidIdx = this.dt.colReorder.order().indexOf(uidIdx);
+        const remapped = rowData[reorderedUidIdx];
+        if (this.props.dp_lookup[remapped] !== undefined) {
+          return remapped;
+        }
+      }
+    }
+    return rowData[uidIdx];
+  }
+
   static defaultProps = {
     hide: [],
     order_by: [["uid", "asc"]],
@@ -110,7 +128,6 @@ export class RowsDisplayTable extends React.Component<TablePluginProps, RowsDisp
       });
     }
     me.ordered_cols.unshift("");
-    const uidColIndex = me.ordered_cols.indexOf("uid");
 
     dom.empty();
     var columns: Array<{ [k: string]: any }> = this.ordered_cols.map(function (x) {
@@ -138,8 +155,8 @@ export class RowsDisplayTable extends React.Component<TablePluginProps, RowsDisp
       if (!me.dt) {
         return "";
       }
-      const individualUidColIdx = me.dt.colReorder.order().indexOf(uidColIndex);
-      const color = me.props.get_color_for_row(me.props.dp_lookup[row[individualUidColIdx]], 1.0);
+      const uid = me.getUidFromRowData(row);
+      const color = me.props.get_color_for_row(me.props.dp_lookup[uid], 1.0);
       return `<span class="${style.colorBlock}" style="background-color: ${color}" />`;
     };
     this.dt = dom.DataTable({
@@ -206,14 +223,13 @@ export class RowsDisplayTable extends React.Component<TablePluginProps, RowsDisp
         }
         const rowIdx = me.dt.cell(this).index().row;
         const row = me.dt.row(rowIdx);
-        const individualUidColIdx = me.dt.colReorder.order().indexOf(uidColIndex);
 
         dom.find(`.table-primary`).removeClass("table-primary");
         const rowNode = row.node();
         if (rowNode) {
           $(rowNode).addClass("table-primary");
         }
-        me.props.setHighlighted([me.props.dp_lookup[row.data()[individualUidColIdx]]]);
+        me.props.setHighlighted([me.props.dp_lookup[me.getUidFromRowData(row.data())]]);
       })
       .on("mouseout", "td", function () {
         if (!me.dt || me.empty) {
@@ -302,15 +318,11 @@ export class RowsDisplayTable extends React.Component<TablePluginProps, RowsDisp
       return;
     }
     const ordered_cols = this.ordered_cols;
-    const ock = dt.colReorder.transpose(
-      Array.from(Array(ordered_cols.length).keys()),
-      "toOriginal",
-    );
 
     dt.clear();
     dt.rows.add(
       selected.map(function (row) {
-        return ock.map((x) => (x == "" ? "" : row[ordered_cols[x]]));
+        return ordered_cols.map((col) => (col == "" ? "" : row[col]));
       }),
     );
     if (dt.search() == "") {

--- a/tests/hiplot.spec.ts
+++ b/tests/hiplot.spec.ts
@@ -491,3 +491,71 @@ test("inverting another axis does not temporarily unhide ticks on an actively fi
   expect(result.hiddenBeforeCount).toBeGreaterThan(0);
   expect(result.flashed).toBe(false);
 });
+
+test("table keeps correct column-value mapping after column reorder and brush update", async ({
+  page,
+}) => {
+  await loadDemo(page);
+  const result = await page.evaluate(async () => {
+    const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+    const hiplot = (window as any).hiplot_last_instance;
+    const table = hiplot?.plugins_ref?.TABLE?.current;
+    const pplot = hiplot?.plugins_ref?.PARALLEL_PLOT?.current;
+    if (!hiplot || !table || !table.dt || !pplot) {
+      return { error: "missing-hiplot-table-or-pplot" };
+    }
+    const dt = table.dt;
+    const expMetricOriginalIdx = table.ordered_cols.indexOf("exp_metric");
+    if (expMetricOriginalIdx < 0) {
+      return { error: "missing-exp-metric-column" };
+    }
+
+    const currentOrder = dt.colReorder.order() as number[];
+    const without = currentOrder.filter((idx) => idx !== expMetricOriginalIdx);
+    // Keep color column first, move exp_metric as the second visible data column.
+    without.splice(2, 0, expMetricOriginalIdx);
+    dt.colReorder.order(without);
+
+    const dims = Array.from(pplot.state.dimensions);
+    if (dims.length === 0) {
+      return { error: "no-parallel-dimensions" };
+    }
+    const brushDim = dims[0];
+    const brushEl = pplot.dimensions_dom
+      .filter((d: string) => d === brushDim)
+      .select(".pplot-brush");
+    pplot.d3brush.move(brushEl, [60, Math.min(260, pplot.h - 20)]);
+    await sleep(300);
+
+    const headers = Array.from(document.querySelectorAll("table.sample-rows-table thead th")).map(
+      (th) => (th.textContent || "").trim(),
+    );
+    const expMetricVisibleIdx = headers.indexOf("exp_metric");
+    if (expMetricVisibleIdx < 0) {
+      return { error: "exp-metric-not-visible", headers };
+    }
+
+    const cells = Array.from(
+      document.querySelectorAll(
+        `table.sample-rows-table tbody tr td:nth-child(${expMetricVisibleIdx + 1})`,
+      ),
+    )
+      .map((td) => (td.textContent || "").trim())
+      .filter((v) => v.length > 0)
+      .slice(0, 20);
+    if (cells.length === 0) {
+      return { error: "no-cells-read" };
+    }
+    const numericCount = cells.filter((v) => Number.isFinite(Number(v))).length;
+    const uidLikeHexCount = cells.filter((v) => /^[a-f0-9]{6,}$/i.test(v)).length;
+    return {
+      cells,
+      numericCount,
+      uidLikeHexCount,
+    };
+  });
+
+  expect(result.error).toBeUndefined();
+  expect(result.numericCount).toBeGreaterThan(0);
+  expect(result.uidLikeHexCount).toBe(0);
+});

--- a/tests/hiplot.spec.ts
+++ b/tests/hiplot.spec.ts
@@ -357,3 +357,137 @@ test("plotxy y-axis tick labels are not clipped for large numeric ranges", async
     })
     .toEqual({ ok: true, reason: expect.stringContaining("minLeft:") });
 });
+
+test("inverted axis orientation is preserved across keep/restore on another axis", async ({
+  page,
+}) => {
+  await loadDemo(page);
+  const result = await page.evaluate(async () => {
+    const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+    const hiplot = (window as any).hiplot_last_instance;
+    const pplot = hiplot?.plugins_ref?.PARALLEL_PLOT?.current;
+    if (!hiplot || !pplot) {
+      return { error: "missing-hiplot-or-pplot" };
+    }
+    const dims = Array.from(pplot.state.dimensions);
+    if (dims.length < 2) {
+      return { error: "not-enough-dimensions" };
+    }
+    const invertDim = dims[0];
+    const filterDim = dims[1];
+    const wasInverted = pplot.state.invert.has(invertDim);
+    const expectedRangeAfterToggle = !wasInverted ? [0, pplot.h] : [pplot.h, 0];
+
+    const invertExtent = pplot.toggleInvertAxis(invertDim);
+    const rangeImmediatelyAfterToggle = pplot.yscale[invertDim].range().slice();
+    pplot.update_ticks(invertDim, invertExtent);
+    await sleep(150);
+    const rangeAfterInvert = pplot.yscale[invertDim].range().slice();
+
+    const brushEl = pplot.dimensions_dom
+      .filter((d: string) => d === filterDim)
+      .select(".pplot-brush");
+    pplot.d3brush.move(brushEl, [60, Math.min(260, pplot.h - 20)]);
+    await sleep(250);
+
+    const selectedCount = hiplot.state.rows_selected.length;
+    const filteredCount = hiplot.state.rows_filtered.length;
+    if (!(selectedCount > 0 && selectedCount < filteredCount)) {
+      return {
+        error: `invalid-selection-size:${selectedCount}/${filteredCount}`,
+        rangeAfterInvert,
+      };
+    }
+
+    hiplot.filterRows(true);
+    await sleep(250);
+    hiplot.restoreAllRows();
+    await sleep(300);
+    const rangeAfterRestore = pplot.yscale[invertDim].range().slice();
+    return {
+      invertDim,
+      filterDim,
+      expectedRangeAfterToggle,
+      rangeImmediatelyAfterToggle,
+      rangeAfterInvert,
+      rangeAfterRestore,
+    };
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.rangeImmediatelyAfterToggle).toEqual(result.expectedRangeAfterToggle);
+  expect(result.rangeAfterInvert).toEqual(result.expectedRangeAfterToggle);
+  expect(result.rangeAfterRestore).toEqual(result.rangeAfterInvert);
+});
+
+test("inverting another axis does not temporarily unhide ticks on an actively filtered axis", async ({
+  page,
+}) => {
+  await loadDemo(page);
+  const result = await page.evaluate(async () => {
+    const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+    const hiplot = (window as any).hiplot_last_instance;
+    const pplot = hiplot?.plugins_ref?.PARALLEL_PLOT?.current;
+    if (!hiplot || !pplot) {
+      return { error: "missing-hiplot-or-pplot" };
+    }
+    const dims = Array.from(pplot.state.dimensions);
+    if (dims.length < 2) {
+      return { error: "not-enough-dimensions" };
+    }
+    const filteredDim = dims[0];
+    const actionDim = dims[1];
+
+    const brushEl = pplot.dimensions_dom
+      .filter((d: string) => d === filteredDim)
+      .select(".pplot-brush");
+    pplot.d3brush.move(brushEl, [60, Math.min(260, pplot.h - 20)]);
+    await sleep(250);
+
+    const dimNode = pplot.dimensions_dom
+      .filter((d: string) => d === filteredDim)
+      .node() as SVGGElement;
+    if (!dimNode) {
+      return { error: "missing-filtered-dimension-node" };
+    }
+
+    const isAxisTick = (el: SVGTextElement) =>
+      !el.classList.contains("pplot-label") && !el.classList.contains("label-name");
+    const hiddenBefore = Array.from(dimNode.querySelectorAll("text")).filter((el) => {
+      const textEl = el as SVGTextElement;
+      return isAxisTick(textEl) && getComputedStyle(textEl).display === "none";
+    }) as SVGTextElement[];
+    if (hiddenBefore.length === 0) {
+      return { error: "no-hidden-ticks-after-brush" };
+    }
+
+    let flashed = false;
+    const watched = new Set(hiddenBefore);
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        const target = mutation.target as SVGTextElement;
+        if (watched.has(target) && getComputedStyle(target).display !== "none") {
+          flashed = true;
+          break;
+        }
+      }
+    });
+    observer.observe(dimNode, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["style", "class"],
+    });
+
+    const invertExtent = pplot.toggleInvertAxis(actionDim);
+    pplot.update_ticks(actionDim, invertExtent);
+    await sleep(300);
+    observer.disconnect();
+
+    return {
+      flashed,
+      hiddenBeforeCount: hiddenBefore.length,
+    };
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.hiddenBeforeCount).toBeGreaterThan(0);
+  expect(result.flashed).toBe(false);
+});

--- a/tests/hiplot.spec.ts
+++ b/tests/hiplot.spec.ts
@@ -559,3 +559,34 @@ test("table keeps correct column-value mapping after column reorder and brush up
   expect(result.numericCount).toBeGreaterThan(0);
   expect(result.uidLikeHexCount).toBe(0);
 });
+
+test("plotxy timestamp axis labels are not scientific notation", async ({ page }) => {
+  await loadDemo(page);
+  const result = await page.evaluate(async () => {
+    const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+    const hiplot = (window as any).hiplot_last_instance;
+    const plotxy = hiplot?.plugins_ref?.XY?.current;
+    if (!plotxy || !plotxy.plot) {
+      return { error: "missing-plotxy" };
+    }
+    plotxy.setState({ axis_x: "timestamp" });
+    await sleep(250);
+    const axisGroups = Array.from(document.querySelectorAll("svg .axis_render"));
+    const xAxis = axisGroups[0];
+    if (!xAxis) {
+      return { error: "missing-x-axis-group" };
+    }
+    const labels = Array.from(xAxis.querySelectorAll(".tick text")).map((el) =>
+      (el.textContent || "").trim(),
+    );
+    const nonEmpty = labels.filter((l) => l.length > 0);
+    if (nonEmpty.length === 0) {
+      return { error: "no-tick-labels" };
+    }
+    const sciCount = nonEmpty.filter((l) => /e[+-]?\d+/i.test(l)).length;
+    return { nonEmptyCount: nonEmpty.length, sciCount, labels: nonEmpty.slice(0, 12) };
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.nonEmptyCount).toBeGreaterThan(0);
+  expect(result.sciCount).toBe(0);
+});

--- a/uv.lock
+++ b/uv.lock
@@ -931,7 +931,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/f4/7d/aed8cd5e4ca52bb85
 
 [[package]]
 name = "hiplot-mm"
-version = "0.0.4rc12"
+version = "0.0.4rc13"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
- parallel plot tick labels flash visible after filtering and then dragging a diff col
- all parallel plot tick marks disappear during dragging, reappear 800ms later
- XY scatter formatting in number (log) mode - previously overlapping labels could create unreadable labels
- datatables reordering columns
- timestamp formatting in XY scatter