### PR TITLE
docs fixes + hip.theme support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,10 +3,10 @@
     "allow": [
       "Bash(npm run build:*)",
       "mcp__plugin_playwright_playwright__browser_drag",
-      "Bash(bun run build:*)",
-      "Bash(pip uninstall:*)",
       "Bash(bunx playwright test:*)",
-      "Bash(./build.sh:*)"
+      "Bash(./build.sh:*)",
+      "mcp__plugin_playwright_playwright__browser_run_code",
+      "Bash(make build:*)"
     ]
   }
 }

--- a/docs/experiment_settings.rst
+++ b/docs/experiment_settings.rst
@@ -22,7 +22,7 @@ Multiple points can share the same parent - this is especially useful when repre
 
 .. raw:: html
 
-    <iframe src="https://mindthemath.github.io/hiplot/_static/demo/demo_line_xy.html" height="1000px" style="width: 100%; border: 0;"></iframe>
+    <iframe src="https://mindthemath.github.io/hiplot/_static/demo/demo_line_xy.html?hip.theme=light" height="1000px" style="width: 100%; border: 0;"></iframe>
 
 
 .. _frontendRenderingSettings:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -7,7 +7,7 @@ Installing
 
 Python version
 ^^^^^^^^^^^^^^
-HiPlot requires python version 3.6 or newer (you can check your python version with :code:`python3 --version`)
+HiPlot requires Python version greater than 3.9 (you can check your Python version with :code:`python3 --version`)
 
 
 Python virtualenv
@@ -38,7 +38,7 @@ Within the activated environment, use the following command to install HiPlot:
 
 .. code-block:: bash
 
-    pip install -U hiplot  # Or for conda users: conda install -c conda-forge hiplot
+    pip install -U "hiplot-mm>=0.0.4"
 
 
 Congratulation, HiPlot is now ready to use! You can either:
@@ -65,7 +65,7 @@ Once we have created this object, we can display it with :class:`hiplot.Experime
 
 .. raw:: html
 
-    <iframe src="./_static/demo/demo_basic_usage.html?hip.PARALLEL_PLOT.height=300" height="700px" width="100%"></iframe>
+    <iframe src="./_static/demo/demo_basic_usage.html?hip.PARALLEL_PLOT.height=300&amp;hip.theme=light" height="700px" width="100%"></iframe>
 
 
 **Learn more** in the tutorial: :ref:`tutoNotebook`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ Given about 7000 experimental datapoints, we want to understand which parameters
 
 .. raw:: html
 
-    <iframe src="./_static/demo/ml1.csv.html?hip.color_by=%22valid+ppl%22&amp;hip.PARALLEL_PLOT.height=300" height="1000px" style="width: 100%; border: 0;"></iframe>
+    <iframe src="./_static/demo/ml1.csv.html?hip.color_by=%22valid+ppl%22&amp;hip.PARALLEL_PLOT.height=300&amp;hip.theme=light" height="1000px" style="width: 100%; border: 0;"></iframe>
 
 
 HiPlot documentation

--- a/docs/tuto_javascript.rst
+++ b/docs/tuto_javascript.rst
@@ -33,7 +33,7 @@ Basic example
 
 .. raw:: html
 
-    <iframe src="./_static/examples_javascript/Basic/index.html" height="700px" width="100%"></iframe>
+    <iframe src="./_static/examples_javascript/Basic/index.html?hip.theme=light" height="700px" width="100%"></iframe>
 
 
 Customizing HiPlot react component
@@ -69,4 +69,4 @@ An advanced example
 
 .. raw:: html
 
-    <iframe src="./_static/examples_javascript/Custom/index.html?hip.PARALLEL_PLOT.height=250" height="400px" width="100%"></iframe>
+    <iframe src="./_static/examples_javascript/Custom/index.html?hip.PARALLEL_PLOT.height=250&amp;hip.theme=light" height="400px" width="100%"></iframe>

--- a/docs/tuto_streamlit.rst
+++ b/docs/tuto_streamlit.rst
@@ -10,9 +10,9 @@ HiPlot component for Streamlit
 Getting started
 ----------------------------------
 
-You'll need both Streamlit (>=0.63 for `components support <https://docs.streamlit.io/develop/concepts/custom-components/intro>`_) and HiPlot (>=0.18)
+You'll need both Streamlit (>=0.63 for `components support <https://docs.streamlit.io/develop/concepts/custom-components/intro>`_) and HiPlot (hiplot-mm >= 0.0.4)
 
->>> pip install -U streamlit hiplot
+>>> pip install -U streamlit "hiplot-mm>=0.0.4"
 
 
 Displaying an :class:`hiplot.Experiment`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hiplot-mm"
-version = "0.0.4rc13"
+version = "0.0.4rc14"
 description = "High dimensional Interactive Plotting tool"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hiplot-mm"
-version = "0.0.4rc14"
+version = "0.0.4rc15"
 description = "High dimensional Interactive Plotting tool"
 readme = "README.md"
 license = "MIT"

--- a/src/distribution/plot.tsx
+++ b/src/distribution/plot.tsx
@@ -10,8 +10,14 @@ import * as d3 from "d3";
 import style from "../hiplot.module.css";
 import { create_d3_scale_without_outliers, ParamDef } from "../infertypes";
 import { convert_to_categorical_input } from "../lib/d3_scales";
-import { foCreateAxisLabel, foDynamicSizeFitContent } from "../lib/svghelpers";
 import { ParamType, Datapoint } from "../types";
+
+function labelTextFromHtml(html: string, fallback: string): string {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html || "";
+  const text = (tmp.textContent || tmp.innerText || "").trim();
+  return text.length ? text : fallback;
+}
 
 const margin = { top: 20, right: 20, bottom: 50, left: 60 };
 
@@ -87,19 +93,11 @@ export class DistributionPlot extends React.Component<DistributionPlotData, {}> 
       );
       d3.select(this.axisBottomName.current)
         .html(null)
-        .append(
-          function () {
-            return foCreateAxisLabel(this.props.param_def, null, null);
-          }.bind(this),
-        )
-        .classed("distrplot_axislabel", true)
-        .attr("x", -4)
-        .attr("text-anchor", "end");
-      d3.select(this.axisBottomName.current)
-        .select(".distrplot_axislabel")
-        .each(function (this: SVGForeignObjectElement) {
-          foDynamicSizeFitContent(this);
-        });
+        .append("text")
+        .attr("text-anchor", "middle")
+        .attr("font-weight", "bold")
+        .attr("fill", "currentColor")
+        .text(labelTextFromHtml(this.props.param_def.label_html, this.props.axis));
       this.axisRight.current.innerHTML = "";
     } else {
       dataScale.range([this.figureHeight(), 0]);
@@ -112,6 +110,13 @@ export class DistributionPlot extends React.Component<DistributionPlotData, {}> 
         .transition()
         .duration(animate ? this.props.animateMs : 0)
         .call(d3.axisLeft(dataScale).ticks(1 + this.props.height / 50));
+      d3.select(this.axisBottomName.current)
+        .html(null)
+        .append("text")
+        .attr("text-anchor", "middle")
+        .attr("font-weight", "bold")
+        .attr("fill", "currentColor")
+        .text("Density");
     }
   }
   createDataScaleAndAxis(): void {
@@ -354,14 +359,21 @@ export class DistributionPlot extends React.Component<DistributionPlotData, {}> 
   }
 
   render() {
-    const leftAxisLabel = this.isVertical() ? "Density" : this.props.axis;
     return (
       <div data-testid="distribution-plot" data-axis={this.props.axis}>
         <svg width={this.props.width} height={this.props.height}>
-          <g transform={`translate(${margin.left}, 15)`} textAnchor="start" fontWeight="bold">
-            <text style={{ stroke: "white", strokeWidth: "0.2em" }}>{leftAxisLabel}</text>
-            <text>{leftAxisLabel}</text>
-          </g>
+          <text
+            x={13}
+            y={15}
+            textAnchor="start"
+            fontWeight="bold"
+            fill="currentColor"
+            className={style.axisLabelText}
+          >
+            {this.isVertical()
+              ? "Density"
+              : labelTextFromHtml(this.props.param_def.label_html, this.props.axis)}
+          </text>
           <g
             ref={this.svgContainer}
             className={style["distr-graph-svg"]}
@@ -386,8 +398,8 @@ export class DistributionPlot extends React.Component<DistributionPlotData, {}> 
             ></g>
             <g
               ref={this.axisBottomName}
-              transform={`translate(${this.figureWidth()}, ${this.props.height - margin.top - 30})`}
-              textAnchor="end"
+              transform={`translate(${this.figureWidth() / 2}, ${this.props.height - margin.top - 10})`}
+              textAnchor="middle"
               fontWeight="bold"
             ></g>
           </g>

--- a/src/hiplot_web.tsx
+++ b/src/hiplot_web.tsx
@@ -16,11 +16,18 @@ import { UploadDataProvider } from "./dataproviders/upload";
 
 export function build_props(extra?: any): HiPlotProps {
   const searchParams = new URLSearchParams(location.search);
+  const themeParam =
+    searchParams.get("hip.theme") ??
+    searchParams.get("hiplot.theme") ??
+    searchParams.get("HIPLOT.theme");
   const darkParam =
     searchParams.get("hip.dark") ??
     searchParams.get("hiplot.dark") ??
     searchParams.get("HIPLOT.dark");
-  const darkValue = normalizeDarkModeSetting(darkParam, "auto");
+  // `hip.theme` is the preferred query parameter. Keep `hip.dark` as a
+  // compatibility fallback for existing links.
+  const themeOrDarkParam = themeParam !== null ? themeParam : darkParam;
+  const darkValue = normalizeDarkModeSetting(themeOrDarkParam, "auto");
   var props = {
     experiment: null,
     persistentState: new PersistentStateInURL("hip"),

--- a/src/infertypes.ts
+++ b/src/infertypes.ts
@@ -387,7 +387,7 @@ export function infertypes(
       }
     }
     if (info.type == ParamType.NUMERICLOG) {
-      info.ticks_format = d3.format(".1e");
+      info.ticks_format = ".1e";
     }
     return info;
   }

--- a/src/plotxy.tsx
+++ b/src/plotxy.tsx
@@ -229,21 +229,37 @@ export class PlotXY extends React.Component<PlotXYProps, PlotXYState> {
       if (
         !paramDef ||
         paramDef.type !== ParamType.NUMERICLOG ||
-        typeof scale.ticks !== "function"
+        typeof scale.domain !== "function"
       ) {
         return null;
       }
-      const ticks = scale.ticks(approxTickCount);
-      if (!Array.isArray(ticks)) {
+      const domain = scale.domain();
+      if (!Array.isArray(domain) || domain.length < 2) {
         return null;
       }
-      const majorTicks = ticks.filter((tick: number) => {
-        if (!Number.isFinite(tick) || tick <= 0) {
-          return false;
+      const dMin = Number(domain[0]);
+      const dMax = Number(domain[domain.length - 1]);
+      if (!Number.isFinite(dMin) || !Number.isFinite(dMax) || dMin <= 0 || dMax <= 0) {
+        return null;
+      }
+      // Generate powers of 10 spanning the domain, including boundary powers
+      // so that e.g. domain [1.05, 99.3] produces ticks [1, 10, 100]
+      const minExp = Math.floor(Math.log10(dMin));
+      const maxExp = Math.ceil(Math.log10(dMax));
+      const majorTicks: number[] = [];
+      for (let exp = minExp; exp <= maxExp; exp++) {
+        majorTicks.push(Math.pow(10, exp));
+      }
+      // Thin out if there are too many powers of 10 for the available space
+      if (majorTicks.length > approxTickCount && majorTicks.length > 2) {
+        const step = Math.ceil(majorTicks.length / approxTickCount);
+        const thinned: number[] = [majorTicks[0]];
+        for (let i = step; i < majorTicks.length - 1; i += step) {
+          thinned.push(majorTicks[i]);
         }
-        const lg = Math.log10(tick);
-        return Math.abs(lg - Math.round(lg)) < 1e-10;
-      });
+        thinned.push(majorTicks[majorTicks.length - 1]);
+        return thinned;
+      }
       return majorTicks.length > 1 ? majorTicks : null;
     }
     function redraw_axis() {

--- a/src/plotxy.tsx
+++ b/src/plotxy.tsx
@@ -15,8 +15,8 @@ import React from "react";
 import { ResizableH } from "./lib/resizable";
 import _ from "underscore";
 import { Datapoint, ParamType } from "./types";
-import { foCreateAxisLabel, foDynamicSizeFitContent } from "./lib/svghelpers";
 import { ContextMenu } from "./contextmenu";
+import { IS_MOBILE } from "./lib/browsercompat";
 
 // DISPLAYS_DATA_DOC_BEGIN
 // Corresponds to values in the dict of `exp.display_data(hip.Displays.XY)`
@@ -46,6 +46,13 @@ interface PlotXYState extends PlotXYDisplayData {
 
 const HIGHLIGHT_PARENT = "parent";
 const HIGHLIGHT_CHILDREN = "children";
+
+function labelTextFromHtml(html: string, fallback: string): string {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html || "";
+  const text = (tmp.textContent || tmp.innerText || "").trim();
+  return text.length ? text : fallback;
+}
 
 interface PlotXYInternal {
   clear_canvas: () => void;
@@ -290,28 +297,51 @@ export class PlotXY extends React.Component<PlotXYProps, PlotXYState> {
               .tickSizeInner(margin.left + margin.right - me.state.width),
           )
           .call((g) => g.select(".domain").remove())
-          .call((g) =>
-            g
-              .select(".tick:last-of-type")
-              .append(function (this: SVGGElement) {
-                const label = foCreateAxisLabel(
-                  me.props.params_def[me.state.axis_y],
-                  me.props.context_menu_ref,
-                );
-                d3.select(label).attr("y", `${-this.transform.baseVal[0].matrix.f + 10}`);
-                return label;
-              })
-              .attr("x", 3)
+          .call((g) => {
+            const pd = me.props.params_def[me.state.axis_y];
+            g.append("text")
+              .attr("x", 13)
+              .attr("y", 25)
               .attr("text-anchor", "start")
               .attr("font-weight", "bold")
-              .classed("plotxy-label", true),
-          )
-          .attr("font-size", null)
-          .call((g) =>
-            g.selectAll(".plotxy-label").each(function () {
-              foDynamicSizeFitContent(this);
-            }),
-          );
+              .attr("fill", "currentColor")
+              .classed(style.axisLabelText, true)
+              .classed("plotxy-label", true)
+              .text(labelTextFromHtml(pd.label_html, pd.name))
+              .append("title")
+              .text(IS_MOBILE ? "Long-press for options" : "Right click for options");
+            g.select(".plotxy-label")
+              .on("contextmenu", function (event) {
+                if (me.props.context_menu_ref && me.props.context_menu_ref.current) {
+                  me.props.context_menu_ref.current.show(event.pageX, event.pageY, pd.name);
+                  event.preventDefault();
+                  event.stopPropagation();
+                }
+              })
+              .on("touchstart", function (event) {
+                if (!me.props.context_menu_ref || !me.props.context_menu_ref.current) return;
+                const target = this as any;
+                target.__longPressFired = false;
+                const touch = (event as TouchEvent).touches[0];
+                target.__longPressTimer = window.setTimeout(() => {
+                  me.props.context_menu_ref.current.show(touch.pageX, touch.pageY, pd.name);
+                  target.__longPressFired = true;
+                  target.__longPressTimer = null;
+                }, 500);
+              })
+              .on("touchend touchcancel touchmove", function (event) {
+                const target = this as any;
+                if (target.__longPressTimer) {
+                  window.clearTimeout(target.__longPressTimer);
+                  target.__longPressTimer = null;
+                }
+                if (target.__longPressFired) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }
+              });
+          })
+          .attr("font-size", null);
       xAxis = (g) =>
         g
           .attr("transform", `translate(0,${me.state.height - margin.bottom})`)
@@ -322,23 +352,6 @@ export class PlotXY extends React.Component<PlotXYProps, PlotXYState> {
               .tickValues(xTickValues as any)
               .tickFormat(xTickFormatter as any)
               .tickSizeInner(margin.bottom + margin.top - me.state.height),
-          )
-          .call((g) =>
-            g.select(".tick:last-of-type").each(function (this: SVGGElement) {
-              const fo = foCreateAxisLabel(
-                me.props.params_def[me.state.axis_x],
-                me.props.context_menu_ref,
-                /* label */ null,
-              );
-              d3.select(fo)
-                .attr("y", 40)
-                .attr("text-anchor", "end")
-                .attr("font-weight", "bold")
-                .classed("plotxy-label", true);
-              const clone = this.cloneNode(false);
-              clone.appendChild(fo);
-              this.parentElement.appendChild(clone);
-            }),
           )
           // Make odd ticks below (to prevent overlap when very long labels)
           .call((g) =>
@@ -354,12 +367,52 @@ export class PlotXY extends React.Component<PlotXYProps, PlotXYState> {
               }
             }),
           )
-          .attr("font-size", null)
-          .call((g) =>
-            g.selectAll(".plotxy-label").each(function () {
-              foDynamicSizeFitContent(this);
-            }),
-          );
+          .call((g) => {
+            const pd = me.props.params_def[me.state.axis_x];
+            const centerX = (margin.left + me.state.width - margin.right) / 2;
+            g.append("text")
+              .attr("x", centerX)
+              .attr("y", 45)
+              .attr("text-anchor", "middle")
+              .attr("font-weight", "bold")
+              .attr("fill", "currentColor")
+              .classed(style.axisLabelText, true)
+              .classed("plotxy-label", true)
+              .text(labelTextFromHtml(pd.label_html, pd.name))
+              .append("title")
+              .text(IS_MOBILE ? "Long-press for options" : "Right click for options");
+            g.select(".plotxy-label")
+              .on("contextmenu", function (event) {
+                if (me.props.context_menu_ref && me.props.context_menu_ref.current) {
+                  me.props.context_menu_ref.current.show(event.pageX, event.pageY, pd.name);
+                  event.preventDefault();
+                  event.stopPropagation();
+                }
+              })
+              .on("touchstart", function (event) {
+                if (!me.props.context_menu_ref || !me.props.context_menu_ref.current) return;
+                const target = this as any;
+                target.__longPressFired = false;
+                const touch = (event as TouchEvent).touches[0];
+                target.__longPressTimer = window.setTimeout(() => {
+                  me.props.context_menu_ref.current.show(touch.pageX, touch.pageY, pd.name);
+                  target.__longPressFired = true;
+                  target.__longPressTimer = null;
+                }, 500);
+              })
+              .on("touchend touchcancel touchmove", function (event) {
+                const target = this as any;
+                if (target.__longPressTimer) {
+                  window.clearTimeout(target.__longPressTimer);
+                  target.__longPressTimer = null;
+                }
+                if (target.__longPressFired) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }
+              });
+          })
+          .attr("font-size", null);
       div
         .selectAll("canvas")
         .attr("width", me.state.width - margin.left - margin.right)
@@ -428,18 +481,31 @@ export class PlotXY extends React.Component<PlotXYProps, PlotXYState> {
       else svg.on("mousemove", moved).on("mouseenter", entered).on("mouseleave", left);
 
       function moved(event) {
+        // Only process hover within the plot area (inside margins).
+        // This allows touch-scrolling over axis labels on mobile.
+        const ex = event.layerX,
+          ey = event.layerY;
+        if (
+          ex < margin.left ||
+          ex > me.state.width - margin.right ||
+          ey < margin.top ||
+          ey > me.state.height - margin.bottom
+        ) {
+          left();
+          return;
+        }
         event.preventDefault();
         var closest = null;
         var closest_dist = null;
         $.each(currently_displayed, function (_, dp) {
-          var dist = (dp["layerX"] - event.layerX) ** 2 + (dp["layerY"] - event.layerY) ** 2;
+          var dist = (dp["layerX"] - ex) ** 2 + (dp["layerY"] - ey) ** 2;
           if (closest_dist == null || dist < closest_dist) {
             closest_dist = dist;
             closest = dp;
           }
         });
         if (closest === null) {
-          dot.attr("transform", `translate(${event.layerX},${event.layerY})`);
+          dot.attr("transform", `translate(${ex},${ey})`);
           dot.select("text").text("No point found?!");
           return;
         }
@@ -576,7 +642,6 @@ export class PlotXY extends React.Component<PlotXYProps, PlotXYState> {
       d3.select(me.canvas_highlighted_ref.current).style("opacity", "0");
       d3.select(me.canvas_lines_ref.current).style("opacity", "1.0");
       if (!highlighted.length) {
-        // Stop highlight
         return;
       }
       d3.select(me.canvas_highlighted_ref.current).style("opacity", "1.0");

--- a/uv.lock
+++ b/uv.lock
@@ -931,7 +931,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/f4/7d/aed8cd5e4ca52bb85
 
 [[package]]
 name = "hiplot-mm"
-version = "0.0.4rc13"
+version = "0.0.4rc14"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/uv.lock
+++ b/uv.lock
@@ -931,7 +931,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/f4/7d/aed8cd5e4ca52bb85
 
 [[package]]
 name = "hiplot-mm"
-version = "0.0.4rc14"
+version = "0.0.4rc15"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
- `hip.theme` instead of `hip.dark` is a lot cleaner.
- explicitly set `hip.theme=light` in docs.